### PR TITLE
Add admin ip fitlering middleware

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -12,7 +12,7 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 import os
 import environ
 
-BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 
 env = environ.Env()
 env.read_env()
@@ -24,7 +24,7 @@ SECRET_KEY = env("SECRET_KEY")
 
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS")
 
-VCAP_SERVICES = env.json('VCAP_SERVICES', {})
+VCAP_SERVICES = env.json("VCAP_SERVICES", {})
 
 INSTALLED_APPS = [
     "main",
@@ -41,7 +41,6 @@ INSTALLED_APPS = [
     # "dal_select2",
     "sass_processor",
     "axes",
-
     # must be last so other apps can override widget rendering
     "django.forms",
 ]
@@ -70,28 +69,28 @@ WSGI_APPLICATION = "config.wsgi.application"
 
 if env("ELASTIC_APM_ENVIRONMENT", default=None):
     ELASTIC_APM = {
-        'SERVICE_NAME': 'return-to-office',
-        'SECRET_TOKEN': env.bool("ELASTIC_APM_SECRET_TOKEN", default=None),
-        'SERVER_URL': 'https://apm.elk.uktrade.digital',
-        'ENVIRONMENT': env("ELASTIC_APM_ENVIRONMENT", default=None)
+        "SERVICE_NAME": "return-to-office",
+        "SECRET_TOKEN": env.bool("ELASTIC_APM_SECRET_TOKEN", default=None),
+        "SERVER_URL": "https://apm.elk.uktrade.digital",
+        "ENVIRONMENT": env("ELASTIC_APM_ENVIRONMENT", default=None),
     }
 
-VCAP_SERVICES = env.json('VCAP_SERVICES', default={})
+VCAP_SERVICES = env.json("VCAP_SERVICES", default={})
 
-if 'postgres' in VCAP_SERVICES:
-    DATABASE_URL = VCAP_SERVICES['postgres'][0]['credentials']['uri']
+if "postgres" in VCAP_SERVICES:
+    DATABASE_URL = VCAP_SERVICES["postgres"][0]["credentials"]["uri"]
 else:
-    DATABASE_URL = os.getenv('DATABASE_URL')
+    DATABASE_URL = os.getenv("DATABASE_URL")
 
-DATABASES = {
-    "default": env.db()
-}
+DATABASES = {"default": env.db()}
 
 # Password validation
 # https://docs.djangoproject.com/en/2.0/ref/settings/#auth-password-validators
 
 AUTH_PASSWORD_VALIDATORS = [
-    {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},  # noqa
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
+    },  # noqa
     {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
     {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
@@ -144,7 +143,7 @@ STATICFILES_FINDERS = [
 ]
 
 SETTINGS_EXPORT = [
-    'DEBUG',
+    "DEBUG",
 ]
 
 MIDDLEWARE = [
@@ -157,6 +156,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "axes.middleware.AxesMiddleware",
+    "main.middleware.IpRestrictionMiddleware",
     "authbroker_client.middleware.ProtectAllViewsMiddleware",
 ]
 
@@ -168,12 +168,20 @@ AUTHENTICATION_BACKENDS = [
 
 AXES_LOGIN_FAILURE_LIMIT = 5
 
-MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
+MESSAGE_STORAGE = "django.contrib.messages.storage.session.SessionStorage"
 
 # we need to store dates in the session, which the default json serializer
 # doesn't support
 SESSION_SERIALIZER = "django.contrib.sessions.serializers.PickleSerializer"
 
-AUTHBROKER_ANONYMOUS_PATHS = ["/pingdom/ping.xml", ]
+AUTHBROKER_ANONYMOUS_PATHS = [
+    "/pingdom/ping.xml",
+]
 
 GOVUK_NOTIFY_API_KEY = env("GOVUK_NOTIFY_API_KEY")
+
+# IP filtering
+IP_RESTRICT = env.bool("IP_RESTRICT")
+IP_RESTRICT_APPS = ["admin"]
+ALLOWED_IPS = env.list("ALLOWED_IPS", default=[])
+ALLOWED_IP_RANGES = env.list("ALLOWED_IP_RANGES", default=[])

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -36,3 +36,6 @@ LOGGING = {
         },
     },
 }
+
+# disable ip restriction for local dev
+IP_RESTRICT = False

--- a/main/middleware.py
+++ b/main/middleware.py
@@ -1,0 +1,64 @@
+import logging
+from ipaddress import ip_address, ip_network
+
+from django.conf import settings
+from django.http import HttpResponse
+from django.urls import resolve, reverse
+from django.urls.exceptions import Resolver404
+
+logger = logging.getLogger(__name__)
+
+
+def _is_valid_ip(client_ip):
+    if not client_ip:
+        return False
+
+    if client_ip in settings.ALLOWED_IPS:
+        return True
+
+    ip_addr = ip_address(client_ip)
+    for cidr in settings.ALLOWED_IP_RANGES:
+        if ip_addr in ip_network(cidr):
+            return True
+
+    return False
+
+
+def _get_client_ip(request):
+    client_ip_index = getattr(settings, "IP_SAFELIST_XFF_INDEX", -2)
+
+    try:
+        return request.META["HTTP_X_FORWARDED_FOR"].split(",")[client_ip_index].strip()
+    except (IndexError, KeyError):
+        logger.warning(
+            "X-Forwarded-For header is missing or does not "
+            "contain enough elements to determine the "
+            "client's ip"
+        )  # noqa: Q003
+        return None
+
+
+def IpRestrictionMiddleware(get_response):
+    def middleware(request):
+
+        try:
+            app_name = resolve(request.path).app_name
+        except Resolver404:
+            app_name = None
+
+        restricted_paths = [
+            reverse(path) for path in getattr(settings, "IP_RESTRICT_PATH_NAMES", [])
+        ]
+
+        if (
+            settings.IP_RESTRICT
+            and app_name in settings.IP_RESTRICT_APPS
+            or request.path in restricted_paths
+        ):
+            client_ip = _get_client_ip(request)
+            if not _is_valid_ip(client_ip):
+                return HttpResponse("Unauthorized", status=401)
+
+        return get_response(request)
+
+    return middleware

--- a/main/tests/test_middleware.py
+++ b/main/tests/test_middleware.py
@@ -1,0 +1,103 @@
+from django.http import HttpResponse
+from django.test import client, RequestFactory, TestCase
+from django.urls import reverse
+
+from main.middleware import IpRestrictionMiddleware
+
+
+def dummy_view(_):
+    return HttpResponse(status=200)
+
+
+class TestIpRestrictionMiddleware(TestCase):
+
+    rf = None
+
+    def setUp(self):
+        self.rf = RequestFactory()
+
+    def test_middleware_is_enabled(self):
+        with self.settings(IP_RESTRICT=True, IP_RESTRICT_APPS=["admin"]):
+            self.assertEqual(self.client.get(reverse("admin:index")).status_code, 401)
+
+    def test_applies_to_specified_apps_only(self):
+        """Only apps listed in `settings.IP_WHITELIST_APPS` should be ip restricted"""
+
+        request = self.rf.get("/")
+
+        with self.settings(IP_RESTRICT=True, IP_RESTRICT_APPS=["admin"]):
+            self.assertEqual(
+                IpRestrictionMiddleware(dummy_view)(request).status_code, 200
+            )
+
+    def test_not_enabled_if_ip_restrict_is_false(self):
+
+        request = self.rf.get(reverse("admin:index"), HTTP_X_FORWARDED_FOR="")
+
+        with self.settings(IP_RESTRICT=False, IP_RESTRICT_APPS=["admin"]):
+            self.assertEqual(
+                IpRestrictionMiddleware(dummy_view)(request).status_code, 200
+            )
+
+    def test_x_forwarded_header(self):
+
+        test_cases = (["1.1.1.1, 2.2.2.2, 3.3.3.3", 200], ["1.1.1.1", 401], ["", 401,])
+
+        for xff_header, expected_status in test_cases:
+            request = self.rf.get(
+                reverse("admin:index"), HTTP_X_FORWARDED_FOR=xff_header
+            )
+
+            with self.settings(
+                IP_RESTRICT=True, IP_RESTRICT_APPS=["admin"], ALLOWED_IPS=["2.2.2.2"]
+            ):
+                self.assertEqual(
+                    IpRestrictionMiddleware(dummy_view)(request).status_code,
+                    expected_status,
+                )
+
+    def test_ips(self):
+
+        test_cases = ([["2.2.2.2"], 200], [["1.1.1.1"], 401])
+
+        for allowed_ips, expected_status in test_cases:
+            with self.settings(
+                IP_RESTRICT=True, IP_RESTRICT_APPS=["admin"], ALLOWED_IPS=allowed_ips
+            ):
+                request = self.rf.get(
+                    reverse("admin:index"),
+                    HTTP_X_FORWARDED_FOR="1.1.1.1, 2.2.2.2, 3.3.3.3",
+                )
+
+                self.assertEqual(
+                    IpRestrictionMiddleware(dummy_view)(request).status_code,
+                    expected_status,
+                )
+
+        with self.settings(
+            IP_RESTRICT=True, IP_RESTRICT_APPS=["admin"], ALLOWED_IPS=["3.3.3.3"]
+        ):
+
+            self.assertEqual(
+                IpRestrictionMiddleware(dummy_view)(request).status_code, 401
+            )
+
+    def test_ip_restricted_path(self):
+
+        test_cases = ([["2.2.2.2"], 200], [["1.1.1.1"], 401])
+
+        for allowed_ips, expected_status in test_cases:
+            with self.settings(
+                IP_RESTRICT=True,
+                IP_RESTRICT_PATH_NAMES=["main:show-bookings"],
+                ALLOWED_IPS=allowed_ips,
+            ):
+                request = self.rf.get(
+                    reverse("main:show-bookings"),
+                    HTTP_X_FORWARDED_FOR="1.1.1.1, 2.2.2.2, 3.3.3.3",
+                )
+
+                self.assertEqual(
+                    IpRestrictionMiddleware(dummy_view)(request).status_code,
+                    expected_status,
+                )


### PR DESCRIPTION
This adds IP filtering middleware to protect the django admin site.

The middleware checks a specific entry of the X_FORWARDED_FOR header to obtain the client's IP. This won't work in local development, so IP filtering needs to be disabled.

This can be done by adding the following to your .env file:

IP_RESTRICT=off 

Also the position in the XFF header depends on the number of hops between the client's browser and the running container.  The CDN adds an additional hop. The XFF index can be configured by setting `settings.IP_SAFELIST_XFF_INDEX`

