### PR TITLE
Fix broken Django 3.1 upgrade.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ black_format:
 setup:
 	scripts/initial-setup.sh
 	make migrations migrate
+	make compilescss
+	make collectstatic
 
 migrations:
 	docker-compose run web python manage.py makemigrations main
@@ -29,6 +31,9 @@ docker_flake8:
 docker_black:
 	docker-compose run --rm web black --check .
 
+pip-check:
+	docker-compose run --rm web pip-check
+
 up:
 	docker-compose up
 
@@ -42,7 +47,7 @@ elevate:
 	docker-compose run web python manage.py elevate_sso_user_permissions
 
 collectstatic:
-	docker-compose run web python manage.py collectstatic
+	docker-compose run web python manage.py collectstatic --noinput
 
 dev-requirements:
 	pip-compile --output-file requirements/base.txt requirements.in/base.in

--- a/requirements.in/base.in
+++ b/requirements.in/base.in
@@ -2,11 +2,11 @@ attrs==18.1.0
 chardet==3.0.4
 dj-database-url==0.5.0
 django-autocomplete-light==3.3.2
-django-axes==5.3.2
+django-axes==5.6.0
 django-compressor==2.4
 django-environ==0.4.5
-django-log-formatter-ecs==0.0.3
-django-sass-processor==0.8
+django-log-formatter-ecs==0.0.5
+django-sass-processor==0.8.2
 django-settings-export==1.2.1
 django-staff-sso-client==2.2.1
 django-webpack-loader==0.7.0

--- a/requirements.in/dev.in
+++ b/requirements.in/dev.in
@@ -7,3 +7,4 @@ pytest==6.0.2
 pytest-cov==2.10.1
 pytest-django==3.10.0
 pytest-xdist==2.1.0
+pip-check==2.6

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,14 +9,14 @@ attrs==18.1.0             # via -r requirements.in/base.in
 certifi==2018.8.24        # via elastic-apm, requests, sentry-sdk
 chardet==3.0.4            # via -r requirements.in/base.in, requests
 dj-database-url==0.5.0    # via -r requirements.in/base.in
-django-appconf==1.0.4     # via django-axes, django-compressor
+django-appconf==1.0.4     # via django-compressor
 django-autocomplete-light==3.3.2  # via -r requirements.in/base.in
-django-axes==5.3.2        # via -r requirements.in/base.in
+django-axes==5.6.0        # via -r requirements.in/base.in
 django-compressor==2.4    # via -r requirements.in/base.in
 django-environ==0.4.5     # via -r requirements.in/base.in
-django-ipware==2.1.0      # via django-axes, django-log-formatter-ecs
-django-log-formatter-ecs==0.0.3  # via -r requirements.in/base.in
-django-sass-processor==0.8  # via -r requirements.in/base.in
+django-ipware==3.0.1      # via django-axes, django-log-formatter-ecs
+django-log-formatter-ecs==0.0.5  # via -r requirements.in/base.in
+django-sass-processor==0.8.2  # via -r requirements.in/base.in
 django-settings-export==1.2.1  # via -r requirements.in/base.in
 django-staff-sso-client==2.2.1  # via -r requirements.in/base.in
 django-webpack-loader==0.7.0  # via -r requirements.in/base.in
@@ -26,9 +26,9 @@ elastic-apm==5.6.0        # via -r requirements.in/base.in
 future==0.18.2            # via notifications-python-client
 gunicorn==19.9.0          # via -r requirements.in/base.in
 idna==2.7                 # via requests
-kubi-ecs-logger==0.0.6    # via django-log-formatter-ecs
+kubi-ecs-logger==0.1.0    # via django-log-formatter-ecs
 libsass==0.20.0           # via -r requirements.in/base.in
-marshmallow==2.19.2       # via kubi-ecs-logger
+marshmallow==3.6.1        # via kubi-ecs-logger
 monotonic==1.5            # via notifications-python-client
 notifications-python-client==5.7.0  # via -r requirements.in/base.in
 oauthlib==2.1.0           # via -r requirements.in/base.in, requests-oauthlib

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,16 +12,17 @@ black==20.8b1             # via -r requirements.in/dev.in
 certifi==2018.8.24        # via elastic-apm, requests, sentry-sdk
 chardet==3.0.4            # via -r requirements.in/base.in, requests
 click==7.1.2              # via black, pip-tools
+colorclass==2.2.0         # via pip-check
 coverage==5.2             # via pytest-cov
 dj-database-url==0.5.0    # via -r requirements.in/base.in
-django-appconf==1.0.4     # via django-axes, django-compressor
+django-appconf==1.0.4     # via django-compressor
 django-autocomplete-light==3.3.2  # via -r requirements.in/base.in
-django-axes==5.3.2        # via -r requirements.in/base.in
+django-axes==5.6.0        # via -r requirements.in/base.in
 django-compressor==2.4    # via -r requirements.in/base.in
 django-environ==0.4.5     # via -r requirements.in/base.in
-django-ipware==2.1.0      # via django-axes, django-log-formatter-ecs
-django-log-formatter-ecs==0.0.3  # via -r requirements.in/base.in
-django-sass-processor==0.8  # via -r requirements.in/base.in
+django-ipware==3.0.1      # via django-axes, django-log-formatter-ecs
+django-log-formatter-ecs==0.0.5  # via -r requirements.in/base.in
+django-sass-processor==0.8.2  # via -r requirements.in/base.in
 django-settings-export==1.2.1  # via -r requirements.in/base.in
 django-staff-sso-client==2.2.1  # via -r requirements.in/base.in
 django-webpack-loader==0.7.0  # via -r requirements.in/base.in
@@ -35,9 +36,9 @@ gunicorn==19.9.0          # via -r requirements.in/base.in
 idna==2.7                 # via requests
 importlib-metadata==1.6.0  # via flake8, pluggy, pytest
 iniconfig==1.0.1          # via pytest
-kubi-ecs-logger==0.0.6    # via django-log-formatter-ecs
+kubi-ecs-logger==0.1.0    # via django-log-formatter-ecs
 libsass==0.20.0           # via -r requirements.in/base.in
-marshmallow==2.19.2       # via kubi-ecs-logger
+marshmallow==3.6.1        # via kubi-ecs-logger
 mccabe==0.6.1             # via flake8
 monotonic==1.5            # via notifications-python-client
 more-itertools==4.3.0     # via pytest
@@ -46,6 +47,7 @@ notifications-python-client==5.7.0  # via -r requirements.in/base.in
 oauthlib==2.1.0           # via -r requirements.in/base.in, requests-oauthlib
 packaging==20.4           # via pytest
 pathspec==0.8.0           # via black
+pip-check==2.6            # via -r requirements.in/dev.in
 pip-tools==5.3.1          # via -r requirements.in/dev.in
 pluggy==0.13.1            # via pytest
 psycopg2-binary==2.7.4    # via -r requirements.in/base.in
@@ -71,6 +73,7 @@ rjsmin==1.1.0             # via django-compressor
 sentry-sdk==0.17.5        # via -r requirements.in/base.in
 six==1.15.0               # via django-compressor, libsass, more-itertools, packaging, pip-tools, python-dateutil
 sqlparse==0.2.4           # via django
+terminaltables==3.1.0     # via pip-check
 toml==0.10.1              # via black, pytest
 typed-ast==1.4.1          # via black
 typing-extensions==3.7.4.3  # via black

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -9,14 +9,14 @@ attrs==18.1.0             # via -r requirements.in/base.in
 certifi==2018.8.24        # via elastic-apm, requests, sentry-sdk
 chardet==3.0.4            # via -r requirements.in/base.in, requests
 dj-database-url==0.5.0    # via -r requirements.in/base.in
-django-appconf==1.0.4     # via django-axes, django-compressor
+django-appconf==1.0.4     # via django-compressor
 django-autocomplete-light==3.3.2  # via -r requirements.in/base.in
-django-axes==5.3.2        # via -r requirements.in/base.in
+django-axes==5.6.0        # via -r requirements.in/base.in
 django-compressor==2.4    # via -r requirements.in/base.in
 django-environ==0.4.5     # via -r requirements.in/base.in
-django-ipware==2.1.0      # via django-axes, django-log-formatter-ecs
-django-log-formatter-ecs==0.0.3  # via -r requirements.in/base.in
-django-sass-processor==0.8  # via -r requirements.in/base.in
+django-ipware==3.0.1      # via django-axes, django-log-formatter-ecs
+django-log-formatter-ecs==0.0.5  # via -r requirements.in/base.in
+django-sass-processor==0.8.2  # via -r requirements.in/base.in
 django-settings-export==1.2.1  # via -r requirements.in/base.in
 django-staff-sso-client==2.2.1  # via -r requirements.in/base.in
 django-webpack-loader==0.7.0  # via -r requirements.in/base.in
@@ -28,9 +28,9 @@ gevent==20.6.2            # via -r requirements.in/prod.in
 greenlet==0.4.16          # via gevent
 gunicorn==19.9.0          # via -r requirements.in/base.in
 idna==2.7                 # via requests
-kubi-ecs-logger==0.0.6    # via django-log-formatter-ecs
+kubi-ecs-logger==0.1.0    # via django-log-formatter-ecs
 libsass==0.20.0           # via -r requirements.in/base.in
-marshmallow==2.19.2       # via kubi-ecs-logger
+marshmallow==3.6.1        # via kubi-ecs-logger
 monotonic==1.5            # via notifications-python-client
 notifications-python-client==5.7.0  # via -r requirements.in/base.in
 oauthlib==2.1.0           # via -r requirements.in/base.in, requests-oauthlib


### PR DESCRIPTION
"make compilescss" did not work, fix by upgrading django-sass-processor
to latest version. This necessitated upgrading other stuff as well.

Also:

  * Add running compilescss and collectstatic to "make setup" so that
    problems like these are found before deployment to prod in the future.

  * Add "make pip-check" to easily check what packages can be upgraded.