### PR TITLE
Fix canceling old bookings with no group/business info.

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -73,8 +73,8 @@ def cancel_booking(req, pk):
                 "date": str(b.booking_date),
                 "building": str(b.building),
                 "floor": str(b.floor),
-                "dit_group": b.group,
-                "business_unit": b.business_unit,
+                "dit_group": b.group or "Unknown",
+                "business_unit": b.business_unit or "Unknown",
             },
         )
 


### PR DESCRIPTION
The gov.uk notify service blows up if personalisation data contains None
values.