### PR TITLE
LST-1234 Upgrade django-staff-sso-client and django.

### DIFF
--- a/requirements.in/base.in
+++ b/requirements.in/base.in
@@ -8,9 +8,9 @@ django-environ==0.4.5
 django-log-formatter-ecs==0.0.5
 django-sass-processor==0.8.2
 django-settings-export==1.2.1
-django-staff-sso-client==2.2.1
+django-staff-sso-client==3.1.0
 django-webpack-loader==0.7.0
-Django==3.1.3
+Django==3.1.4
 elastic-apm==5.6.0
 gunicorn==19.9.0
 libsass==0.20.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,9 +18,9 @@ django-ipware==3.0.1      # via django-axes, django-log-formatter-ecs
 django-log-formatter-ecs==0.0.5  # via -r requirements.in/base.in
 django-sass-processor==0.8.2  # via -r requirements.in/base.in
 django-settings-export==1.2.1  # via -r requirements.in/base.in
-django-staff-sso-client==2.2.1  # via -r requirements.in/base.in
+django-staff-sso-client==3.1.0  # via -r requirements.in/base.in
 django-webpack-loader==0.7.0  # via -r requirements.in/base.in
-django==3.1.3             # via -r requirements.in/base.in, django-appconf, django-axes, django-settings-export, django-staff-sso-client
+django==3.1.4             # via -r requirements.in/base.in, django-appconf, django-axes, django-settings-export, django-staff-sso-client
 docopt==0.6.2             # via notifications-python-client
 elastic-apm==5.6.0        # via -r requirements.in/base.in
 future==0.18.2            # via notifications-python-client

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -24,9 +24,9 @@ django-ipware==3.0.1      # via django-axes, django-log-formatter-ecs
 django-log-formatter-ecs==0.0.5  # via -r requirements.in/base.in
 django-sass-processor==0.8.2  # via -r requirements.in/base.in
 django-settings-export==1.2.1  # via -r requirements.in/base.in
-django-staff-sso-client==2.2.1  # via -r requirements.in/base.in
+django-staff-sso-client==3.1.0  # via -r requirements.in/base.in
 django-webpack-loader==0.7.0  # via -r requirements.in/base.in
-django==3.1.3             # via -r requirements.in/base.in, django-appconf, django-axes, django-settings-export, django-staff-sso-client
+django==3.1.4             # via -r requirements.in/base.in, django-appconf, django-axes, django-settings-export, django-staff-sso-client
 docopt==0.6.2             # via notifications-python-client
 elastic-apm==5.6.0        # via -r requirements.in/base.in
 execnet==1.7.1            # via pytest-xdist

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -18,9 +18,9 @@ django-ipware==3.0.1      # via django-axes, django-log-formatter-ecs
 django-log-formatter-ecs==0.0.5  # via -r requirements.in/base.in
 django-sass-processor==0.8.2  # via -r requirements.in/base.in
 django-settings-export==1.2.1  # via -r requirements.in/base.in
-django-staff-sso-client==2.2.1  # via -r requirements.in/base.in
+django-staff-sso-client==3.1.0  # via -r requirements.in/base.in
 django-webpack-loader==0.7.0  # via -r requirements.in/base.in
-django==3.1.3             # via -r requirements.in/base.in, django-appconf, django-axes, django-settings-export, django-staff-sso-client
+django==3.1.4             # via -r requirements.in/base.in, django-appconf, django-axes, django-settings-export, django-staff-sso-client
 docopt==0.6.2             # via notifications-python-client
 elastic-apm==5.6.0        # via -r requirements.in/base.in
 future==0.18.2            # via notifications-python-client


### PR DESCRIPTION
This fixes the bug in django-staff-sso-client where users clicking a link
in an email get the authentication page, but after logging in, it would
just dump them at the home page instead of the actual linked page.