### PR TITLE
LST-1347 Upgrade packages to remove vulnerability.

### DIFF
--- a/requirements.in/base.in
+++ b/requirements.in/base.in
@@ -1,4 +1,4 @@
-attrs==18.1.0
+attrs==19.2.0
 chardet==3.0.4
 dj-database-url==0.5.0
 django-autocomplete-light==3.3.2

--- a/requirements.in/dev.in
+++ b/requirements.in/dev.in
@@ -5,7 +5,8 @@ factory-boy==3.0.1
 flake8==3.8.3
 freezegun==1.0.0
 pip-tools==5.3.1
-pytest==6.0.2
+pytest==6.2.3
+py==1.10.0
 pytest-cov==2.10.1
 pytest-django==3.10.0
 pytest-xdist==2.1.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,47 +4,119 @@
 #
 #    pip-compile --output-file=requirements/base.txt requirements.in/base.in
 #
-asgiref==3.2.10           # via django
-attrs==18.1.0             # via -r requirements.in/base.in
-certifi==2018.8.24        # via elastic-apm, requests, sentry-sdk
-chardet==3.0.4            # via -r requirements.in/base.in, requests
-dj-database-url==0.5.0    # via -r requirements.in/base.in
-django-appconf==1.0.4     # via django-compressor
-django-autocomplete-light==3.3.2  # via -r requirements.in/base.in
-django-axes==5.6.0        # via -r requirements.in/base.in
-django-compressor==2.4    # via -r requirements.in/base.in
-django-environ==0.4.5     # via -r requirements.in/base.in
-django-ipware==3.0.1      # via django-axes, django-log-formatter-ecs
-django-log-formatter-ecs==0.0.5  # via -r requirements.in/base.in
-django-sass-processor==0.8.2  # via -r requirements.in/base.in
-django-settings-export==1.2.1  # via -r requirements.in/base.in
-django-staff-sso-client==3.1.0  # via -r requirements.in/base.in
-django-webpack-loader==0.7.0  # via -r requirements.in/base.in
-django==3.1.4             # via -r requirements.in/base.in, django-appconf, django-axes, django-settings-export, django-staff-sso-client
-docopt==0.6.2             # via notifications-python-client
-elastic-apm==5.6.0        # via -r requirements.in/base.in
-future==0.18.2            # via notifications-python-client
-gunicorn==19.9.0          # via -r requirements.in/base.in
-idna==2.7                 # via requests
-kubi-ecs-logger==0.1.0    # via django-log-formatter-ecs
-libsass==0.20.0           # via -r requirements.in/base.in
-marshmallow==3.6.1        # via kubi-ecs-logger
-mohawk==1.1.0             # via -r requirements.in/base.in
-monotonic==1.5            # via notifications-python-client
-notifications-python-client==5.7.0  # via -r requirements.in/base.in
-oauthlib==2.1.0           # via -r requirements.in/base.in, requests-oauthlib
-psycopg2-binary==2.7.4    # via -r requirements.in/base.in
-psycopg2==2.7.4           # via -r requirements.in/base.in
-pyjwt==1.7.1              # via notifications-python-client
-python-dateutil==2.7.3    # via -r requirements.in/base.in
-python-dotenv==0.9.1      # via -r requirements.in/base.in
-pytz==2018.3              # via -r requirements.in/base.in, django
-rcssmin==1.0.6            # via django-compressor
-requests-oauthlib==1.0.0  # via -r requirements.in/base.in, django-staff-sso-client
-requests==2.21.0          # via -r requirements.in/base.in, notifications-python-client, requests-oauthlib
-rjsmin==1.1.0             # via django-compressor
-sentry-sdk==0.17.5        # via -r requirements.in/base.in
-six==1.15.0               # via django-compressor, libsass, mohawk, python-dateutil
-sqlparse==0.2.4           # via django
-urllib3==1.24.2           # via elastic-apm, requests, sentry-sdk
-whitenoise==5.2.0         # via -r requirements.in/base.in
+asgiref==3.2.10
+    # via django
+attrs==19.2.0
+    # via -r requirements.in/base.in
+certifi==2018.8.24
+    # via
+    #   elastic-apm
+    #   requests
+    #   sentry-sdk
+chardet==3.0.4
+    # via
+    #   -r requirements.in/base.in
+    #   requests
+dj-database-url==0.5.0
+    # via -r requirements.in/base.in
+django-appconf==1.0.4
+    # via django-compressor
+django-autocomplete-light==3.3.2
+    # via -r requirements.in/base.in
+django-axes==5.6.0
+    # via -r requirements.in/base.in
+django-compressor==2.4
+    # via -r requirements.in/base.in
+django-environ==0.4.5
+    # via -r requirements.in/base.in
+django-ipware==3.0.1
+    # via
+    #   django-axes
+    #   django-log-formatter-ecs
+django-log-formatter-ecs==0.0.5
+    # via -r requirements.in/base.in
+django-sass-processor==0.8.2
+    # via -r requirements.in/base.in
+django-settings-export==1.2.1
+    # via -r requirements.in/base.in
+django-staff-sso-client==3.1.0
+    # via -r requirements.in/base.in
+django-webpack-loader==0.7.0
+    # via -r requirements.in/base.in
+django==3.1.4
+    # via
+    #   -r requirements.in/base.in
+    #   django-appconf
+    #   django-axes
+    #   django-settings-export
+    #   django-staff-sso-client
+docopt==0.6.2
+    # via notifications-python-client
+elastic-apm==5.6.0
+    # via -r requirements.in/base.in
+future==0.18.2
+    # via notifications-python-client
+gunicorn==19.9.0
+    # via -r requirements.in/base.in
+idna==2.7
+    # via requests
+kubi-ecs-logger==0.1.0
+    # via django-log-formatter-ecs
+libsass==0.20.0
+    # via -r requirements.in/base.in
+marshmallow==3.6.1
+    # via kubi-ecs-logger
+mohawk==1.1.0
+    # via -r requirements.in/base.in
+monotonic==1.5
+    # via notifications-python-client
+notifications-python-client==5.7.0
+    # via -r requirements.in/base.in
+oauthlib==2.1.0
+    # via
+    #   -r requirements.in/base.in
+    #   requests-oauthlib
+psycopg2-binary==2.7.4
+    # via -r requirements.in/base.in
+psycopg2==2.7.4
+    # via -r requirements.in/base.in
+pyjwt==1.7.1
+    # via notifications-python-client
+python-dateutil==2.7.3
+    # via -r requirements.in/base.in
+python-dotenv==0.9.1
+    # via -r requirements.in/base.in
+pytz==2018.3
+    # via
+    #   -r requirements.in/base.in
+    #   django
+rcssmin==1.0.6
+    # via django-compressor
+requests-oauthlib==1.0.0
+    # via
+    #   -r requirements.in/base.in
+    #   django-staff-sso-client
+requests==2.21.0
+    # via
+    #   -r requirements.in/base.in
+    #   notifications-python-client
+    #   requests-oauthlib
+rjsmin==1.1.0
+    # via django-compressor
+sentry-sdk==0.17.5
+    # via -r requirements.in/base.in
+six==1.15.0
+    # via
+    #   django-compressor
+    #   libsass
+    #   mohawk
+    #   python-dateutil
+sqlparse==0.2.4
+    # via django
+urllib3==1.24.2
+    # via
+    #   elastic-apm
+    #   requests
+    #   sentry-sdk
+whitenoise==5.2.0
+    # via -r requirements.in/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,87 +4,208 @@
 #
 #    pip-compile --output-file=requirements/dev.txt requirements.in/dev.in
 #
-apipkg==1.5               # via execnet
-appdirs==1.4.4            # via black
-asgiref==3.2.10           # via django
-attrs==18.1.0             # via -r requirements.in/base.in, pytest
-black==20.8b1             # via -r requirements.in/dev.in
-certifi==2018.8.24        # via elastic-apm, requests, sentry-sdk
-chardet==3.0.4            # via -r requirements.in/base.in, requests
-click==7.1.2              # via black, pip-tools
-colorclass==2.2.0         # via pip-check
-coverage==5.2             # via pytest-cov
-dj-database-url==0.5.0    # via -r requirements.in/base.in
-django-appconf==1.0.4     # via django-compressor
-django-autocomplete-light==3.3.2  # via -r requirements.in/base.in
-django-axes==5.6.0        # via -r requirements.in/base.in
-django-compressor==2.4    # via -r requirements.in/base.in
-django-environ==0.4.5     # via -r requirements.in/base.in
-django-ipware==3.0.1      # via django-axes, django-log-formatter-ecs
-django-log-formatter-ecs==0.0.5  # via -r requirements.in/base.in
-django-sass-processor==0.8.2  # via -r requirements.in/base.in
-django-settings-export==1.2.1  # via -r requirements.in/base.in
-django-staff-sso-client==3.1.0  # via -r requirements.in/base.in
-django-webpack-loader==0.7.0  # via -r requirements.in/base.in
-django==3.1.4             # via -r requirements.in/base.in, django-appconf, django-axes, django-settings-export, django-staff-sso-client
-docopt==0.6.2             # via notifications-python-client
-elastic-apm==5.6.0        # via -r requirements.in/base.in
-execnet==1.7.1            # via pytest-xdist
-factory-boy==3.0.1        # via -r requirements.in/dev.in
-faker==4.1.3              # via factory-boy
-flake8==3.8.3             # via -r requirements.in/dev.in
-freezegun==1.0.0          # via -r requirements.in/dev.in
-future==0.18.2            # via notifications-python-client
-gunicorn==19.9.0          # via -r requirements.in/base.in
-idna==2.7                 # via requests
-importlib-metadata==2.0.0  # via flake8, pluggy, pytest
-iniconfig==1.0.1          # via pytest
-kubi-ecs-logger==0.1.0    # via django-log-formatter-ecs
-libsass==0.20.0           # via -r requirements.in/base.in
-marshmallow==3.6.1        # via kubi-ecs-logger
-mccabe==0.6.1             # via flake8
-mohawk==1.1.0             # via -r requirements.in/base.in
-monotonic==1.5            # via notifications-python-client
-more-itertools==4.3.0     # via pytest
-mypy-extensions==0.4.3    # via black
-notifications-python-client==5.7.0  # via -r requirements.in/base.in
-oauthlib==2.1.0           # via -r requirements.in/base.in, requests-oauthlib
-packaging==20.4           # via pytest
-pathspec==0.8.0           # via black
-pip-check==2.6            # via -r requirements.in/dev.in
-pip-tools==5.3.1          # via -r requirements.in/dev.in
-pluggy==0.13.1            # via pytest
-psycopg2-binary==2.7.4    # via -r requirements.in/base.in
-psycopg2==2.7.4           # via -r requirements.in/base.in
-py==1.9.0                 # via pytest
-pycodestyle==2.6.0        # via flake8
-pyflakes==2.2.0           # via flake8
-pyjwt==1.7.1              # via notifications-python-client
-pyparsing==2.2.0          # via packaging
-pytest-cov==2.10.1        # via -r requirements.in/dev.in
-pytest-django==3.10.0     # via -r requirements.in/dev.in
-pytest-forked==1.2.0      # via pytest-xdist
-pytest-xdist==2.1.0       # via -r requirements.in/dev.in
-pytest==6.0.2             # via -r requirements.in/dev.in, pytest-cov, pytest-django, pytest-forked, pytest-xdist
-python-dateutil==2.7.3    # via -r requirements.in/base.in, faker, freezegun
-python-dotenv==0.9.1      # via -r requirements.in/base.in
-pytz==2018.3              # via -r requirements.in/base.in, django
-rcssmin==1.0.6            # via django-compressor
-regex==2020.6.8           # via black
-requests-oauthlib==1.0.0  # via -r requirements.in/base.in, django-staff-sso-client
-requests==2.21.0          # via -r requirements.in/base.in, notifications-python-client, requests-oauthlib
-rjsmin==1.1.0             # via django-compressor
-sentry-sdk==0.17.5        # via -r requirements.in/base.in
-six==1.15.0               # via django-compressor, libsass, mohawk, more-itertools, packaging, pip-tools, python-dateutil
-sqlparse==0.2.4           # via django
-terminaltables==3.1.0     # via pip-check
-text-unidecode==1.3       # via faker
-toml==0.10.1              # via black, pytest
-typed-ast==1.4.1          # via black
-typing-extensions==3.7.4.3  # via black
-urllib3==1.24.2           # via elastic-apm, requests, sentry-sdk
-whitenoise==5.2.0         # via -r requirements.in/base.in
-zipp==3.4.0               # via importlib-metadata
+apipkg==1.5
+    # via execnet
+appdirs==1.4.4
+    # via black
+asgiref==3.2.10
+    # via django
+attrs==19.2.0
+    # via
+    #   -r requirements.in/base.in
+    #   pytest
+black==20.8b1
+    # via -r requirements.in/dev.in
+certifi==2018.8.24
+    # via
+    #   elastic-apm
+    #   requests
+    #   sentry-sdk
+chardet==3.0.4
+    # via
+    #   -r requirements.in/base.in
+    #   requests
+click==7.1.2
+    # via
+    #   black
+    #   pip-tools
+colorclass==2.2.0
+    # via pip-check
+coverage==5.2
+    # via pytest-cov
+dj-database-url==0.5.0
+    # via -r requirements.in/base.in
+django-appconf==1.0.4
+    # via django-compressor
+django-autocomplete-light==3.3.2
+    # via -r requirements.in/base.in
+django-axes==5.6.0
+    # via -r requirements.in/base.in
+django-compressor==2.4
+    # via -r requirements.in/base.in
+django-environ==0.4.5
+    # via -r requirements.in/base.in
+django-ipware==3.0.1
+    # via
+    #   django-axes
+    #   django-log-formatter-ecs
+django-log-formatter-ecs==0.0.5
+    # via -r requirements.in/base.in
+django-sass-processor==0.8.2
+    # via -r requirements.in/base.in
+django-settings-export==1.2.1
+    # via -r requirements.in/base.in
+django-staff-sso-client==3.1.0
+    # via -r requirements.in/base.in
+django-webpack-loader==0.7.0
+    # via -r requirements.in/base.in
+django==3.1.4
+    # via
+    #   -r requirements.in/base.in
+    #   django-appconf
+    #   django-axes
+    #   django-settings-export
+    #   django-staff-sso-client
+docopt==0.6.2
+    # via notifications-python-client
+elastic-apm==5.6.0
+    # via -r requirements.in/base.in
+execnet==1.7.1
+    # via pytest-xdist
+factory-boy==3.0.1
+    # via -r requirements.in/dev.in
+faker==4.1.3
+    # via factory-boy
+flake8==3.8.3
+    # via -r requirements.in/dev.in
+freezegun==1.0.0
+    # via -r requirements.in/dev.in
+future==0.18.2
+    # via notifications-python-client
+gunicorn==19.9.0
+    # via -r requirements.in/base.in
+idna==2.7
+    # via requests
+iniconfig==1.0.1
+    # via pytest
+kubi-ecs-logger==0.1.0
+    # via django-log-formatter-ecs
+libsass==0.20.0
+    # via -r requirements.in/base.in
+marshmallow==3.6.1
+    # via kubi-ecs-logger
+mccabe==0.6.1
+    # via flake8
+mohawk==1.1.0
+    # via -r requirements.in/base.in
+monotonic==1.5
+    # via notifications-python-client
+mypy-extensions==0.4.3
+    # via black
+notifications-python-client==5.7.0
+    # via -r requirements.in/base.in
+oauthlib==2.1.0
+    # via
+    #   -r requirements.in/base.in
+    #   requests-oauthlib
+packaging==20.4
+    # via pytest
+pathspec==0.8.0
+    # via black
+pip-check==2.6
+    # via -r requirements.in/dev.in
+pip-tools==5.3.1
+    # via -r requirements.in/dev.in
+pluggy==0.13.1
+    # via pytest
+psycopg2-binary==2.7.4
+    # via -r requirements.in/base.in
+psycopg2==2.7.4
+    # via -r requirements.in/base.in
+py==1.10.0
+    # via
+    #   -r requirements.in/dev.in
+    #   pytest
+pycodestyle==2.6.0
+    # via flake8
+pyflakes==2.2.0
+    # via flake8
+pyjwt==1.7.1
+    # via notifications-python-client
+pyparsing==2.2.0
+    # via packaging
+pytest-cov==2.10.1
+    # via -r requirements.in/dev.in
+pytest-django==3.10.0
+    # via -r requirements.in/dev.in
+pytest-forked==1.2.0
+    # via pytest-xdist
+pytest-xdist==2.1.0
+    # via -r requirements.in/dev.in
+pytest==6.2.3
+    # via
+    #   -r requirements.in/dev.in
+    #   pytest-cov
+    #   pytest-django
+    #   pytest-forked
+    #   pytest-xdist
+python-dateutil==2.7.3
+    # via
+    #   -r requirements.in/base.in
+    #   faker
+    #   freezegun
+python-dotenv==0.9.1
+    # via -r requirements.in/base.in
+pytz==2018.3
+    # via
+    #   -r requirements.in/base.in
+    #   django
+rcssmin==1.0.6
+    # via django-compressor
+regex==2020.6.8
+    # via black
+requests-oauthlib==1.0.0
+    # via
+    #   -r requirements.in/base.in
+    #   django-staff-sso-client
+requests==2.21.0
+    # via
+    #   -r requirements.in/base.in
+    #   notifications-python-client
+    #   requests-oauthlib
+rjsmin==1.1.0
+    # via django-compressor
+sentry-sdk==0.17.5
+    # via -r requirements.in/base.in
+six==1.15.0
+    # via
+    #   django-compressor
+    #   libsass
+    #   mohawk
+    #   packaging
+    #   pip-tools
+    #   python-dateutil
+sqlparse==0.2.4
+    # via django
+terminaltables==3.1.0
+    # via pip-check
+text-unidecode==1.3
+    # via faker
+toml==0.10.1
+    # via
+    #   black
+    #   pytest
+typed-ast==1.4.1
+    # via black
+typing-extensions==3.7.4.3
+    # via black
+urllib3==1.24.2
+    # via
+    #   elastic-apm
+    #   requests
+    #   sentry-sdk
+whitenoise==5.2.0
+    # via -r requirements.in/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -4,55 +4,132 @@
 #
 #    pip-compile --output-file=requirements/prod.txt requirements.in/prod.in
 #
-asgiref==3.2.10           # via django
-attrs==18.1.0             # via -r requirements.in/base.in
-certifi==2018.8.24        # via elastic-apm, requests, sentry-sdk
-chardet==3.0.4            # via -r requirements.in/base.in, requests
-dj-database-url==0.5.0    # via -r requirements.in/base.in
-django-appconf==1.0.4     # via django-compressor
-django-autocomplete-light==3.3.2  # via -r requirements.in/base.in
-django-axes==5.6.0        # via -r requirements.in/base.in
-django-compressor==2.4    # via -r requirements.in/base.in
-django-environ==0.4.5     # via -r requirements.in/base.in
-django-ipware==3.0.1      # via django-axes, django-log-formatter-ecs
-django-log-formatter-ecs==0.0.5  # via -r requirements.in/base.in
-django-sass-processor==0.8.2  # via -r requirements.in/base.in
-django-settings-export==1.2.1  # via -r requirements.in/base.in
-django-staff-sso-client==3.1.0  # via -r requirements.in/base.in
-django-webpack-loader==0.7.0  # via -r requirements.in/base.in
-django==3.1.4             # via -r requirements.in/base.in, django-appconf, django-axes, django-settings-export, django-staff-sso-client
-docopt==0.6.2             # via notifications-python-client
-elastic-apm==5.6.0        # via -r requirements.in/base.in
-future==0.18.2            # via notifications-python-client
-gevent==20.6.2            # via -r requirements.in/prod.in
-greenlet==0.4.16          # via gevent
-gunicorn==19.9.0          # via -r requirements.in/base.in
-idna==2.7                 # via requests
-kubi-ecs-logger==0.1.0    # via django-log-formatter-ecs
-libsass==0.20.0           # via -r requirements.in/base.in
-marshmallow==3.6.1        # via kubi-ecs-logger
-mohawk==1.1.0             # via -r requirements.in/base.in
-monotonic==1.5            # via notifications-python-client
-notifications-python-client==5.7.0  # via -r requirements.in/base.in
-oauthlib==2.1.0           # via -r requirements.in/base.in, requests-oauthlib
-psycogreen==1.0.2         # via -r requirements.in/prod.in
-psycopg2-binary==2.7.4    # via -r requirements.in/base.in
-psycopg2==2.7.4           # via -r requirements.in/base.in
-pyjwt==1.7.1              # via notifications-python-client
-python-dateutil==2.7.3    # via -r requirements.in/base.in
-python-dotenv==0.9.1      # via -r requirements.in/base.in
-pytz==2018.3              # via -r requirements.in/base.in, django
-rcssmin==1.0.6            # via django-compressor
-requests-oauthlib==1.0.0  # via -r requirements.in/base.in, django-staff-sso-client
-requests==2.21.0          # via -r requirements.in/base.in, notifications-python-client, requests-oauthlib
-rjsmin==1.1.0             # via django-compressor
-sentry-sdk==0.17.5        # via -r requirements.in/base.in
-six==1.15.0               # via django-compressor, libsass, mohawk, python-dateutil
-sqlparse==0.2.4           # via django
-urllib3==1.24.2           # via elastic-apm, requests, sentry-sdk
-whitenoise==5.2.0         # via -r requirements.in/base.in
-zope.event==4.4           # via gevent
-zope.interface==5.1.0     # via gevent
+asgiref==3.2.10
+    # via django
+attrs==19.2.0
+    # via -r requirements.in/base.in
+certifi==2018.8.24
+    # via
+    #   elastic-apm
+    #   requests
+    #   sentry-sdk
+chardet==3.0.4
+    # via
+    #   -r requirements.in/base.in
+    #   requests
+dj-database-url==0.5.0
+    # via -r requirements.in/base.in
+django-appconf==1.0.4
+    # via django-compressor
+django-autocomplete-light==3.3.2
+    # via -r requirements.in/base.in
+django-axes==5.6.0
+    # via -r requirements.in/base.in
+django-compressor==2.4
+    # via -r requirements.in/base.in
+django-environ==0.4.5
+    # via -r requirements.in/base.in
+django-ipware==3.0.1
+    # via
+    #   django-axes
+    #   django-log-formatter-ecs
+django-log-formatter-ecs==0.0.5
+    # via -r requirements.in/base.in
+django-sass-processor==0.8.2
+    # via -r requirements.in/base.in
+django-settings-export==1.2.1
+    # via -r requirements.in/base.in
+django-staff-sso-client==3.1.0
+    # via -r requirements.in/base.in
+django-webpack-loader==0.7.0
+    # via -r requirements.in/base.in
+django==3.1.4
+    # via
+    #   -r requirements.in/base.in
+    #   django-appconf
+    #   django-axes
+    #   django-settings-export
+    #   django-staff-sso-client
+docopt==0.6.2
+    # via notifications-python-client
+elastic-apm==5.6.0
+    # via -r requirements.in/base.in
+future==0.18.2
+    # via notifications-python-client
+gevent==20.6.2
+    # via -r requirements.in/prod.in
+greenlet==0.4.16
+    # via gevent
+gunicorn==19.9.0
+    # via -r requirements.in/base.in
+idna==2.7
+    # via requests
+kubi-ecs-logger==0.1.0
+    # via django-log-formatter-ecs
+libsass==0.20.0
+    # via -r requirements.in/base.in
+marshmallow==3.6.1
+    # via kubi-ecs-logger
+mohawk==1.1.0
+    # via -r requirements.in/base.in
+monotonic==1.5
+    # via notifications-python-client
+notifications-python-client==5.7.0
+    # via -r requirements.in/base.in
+oauthlib==2.1.0
+    # via
+    #   -r requirements.in/base.in
+    #   requests-oauthlib
+psycogreen==1.0.2
+    # via -r requirements.in/prod.in
+psycopg2-binary==2.7.4
+    # via -r requirements.in/base.in
+psycopg2==2.7.4
+    # via -r requirements.in/base.in
+pyjwt==1.7.1
+    # via notifications-python-client
+python-dateutil==2.7.3
+    # via -r requirements.in/base.in
+python-dotenv==0.9.1
+    # via -r requirements.in/base.in
+pytz==2018.3
+    # via
+    #   -r requirements.in/base.in
+    #   django
+rcssmin==1.0.6
+    # via django-compressor
+requests-oauthlib==1.0.0
+    # via
+    #   -r requirements.in/base.in
+    #   django-staff-sso-client
+requests==2.21.0
+    # via
+    #   -r requirements.in/base.in
+    #   notifications-python-client
+    #   requests-oauthlib
+rjsmin==1.1.0
+    # via django-compressor
+sentry-sdk==0.17.5
+    # via -r requirements.in/base.in
+six==1.15.0
+    # via
+    #   django-compressor
+    #   libsass
+    #   mohawk
+    #   python-dateutil
+sqlparse==0.2.4
+    # via django
+urllib3==1.24.2
+    # via
+    #   elastic-apm
+    #   requests
+    #   sentry-sdk
+whitenoise==5.2.0
+    # via -r requirements.in/base.in
+zope.event==4.4
+    # via gevent
+zope.interface==5.1.0
+    # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
"py" package has to be upgraded, which is being pulled in by pytest,
so upgrade pytest. That conflicted with attrs, so upgrade that as well.