### PR TITLE
LST-1383 Upgrade notifications-python-client.

### DIFF
--- a/requirements.in/base.in
+++ b/requirements.in/base.in
@@ -16,7 +16,7 @@ elastic-apm==5.6.0
 gunicorn==19.9.0
 libsass==0.20.0
 mohawk==1.1.0
-notifications-python-client==5.7.0
+notifications-python-client==5.7.1
 oauthlib==2.1.0
 psycopg2-binary==2.7.4
 psycopg2==2.7.4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -74,7 +74,7 @@ mohawk==1.1.0
     # via -r requirements.in/base.in
 monotonic==1.6
     # via notifications-python-client
-notifications-python-client==5.7.0
+notifications-python-client==5.7.1
     # via -r requirements.in/base.in
 oauthlib==2.1.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -113,7 +113,7 @@ monotonic==1.6
     # via notifications-python-client
 mypy-extensions==0.4.3
     # via black
-notifications-python-client==5.7.0
+notifications-python-client==5.7.1
     # via -r requirements.in/base.in
 oauthlib==2.1.0
     # via

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -78,7 +78,7 @@ mohawk==1.1.0
     # via -r requirements.in/base.in
 monotonic==1.6
     # via notifications-python-client
-notifications-python-client==5.7.0
+notifications-python-client==5.7.1
     # via -r requirements.in/base.in
 oauthlib==2.1.0
     # via


### PR DESCRIPTION
The old version can't handle a newer PyJWT.