### PR TITLE
fix: return None if no MO_MAPPING exists for a mitigation outcome

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -190,7 +190,7 @@ class PRA(models.Model):
         return self.RC_MAPPING[self.risk_category]
 
     def mitigation_outcome_desc(self):
-        return self.MO_MAPPING[self.mitigation_outcome]
+        return self.MO_MAPPING.get(self.mitigation_outcome)
 
     def needs_staff_member_approval(self) -> bool:
         """Does this PRA need to be approved by the staff member?"""


### PR DESCRIPTION
Activity stream ingest is failing for PRAs due to a KeyError when mapping mitigation outcomes. This fixes the issue by returning None in the case of no mapping.